### PR TITLE
Update dependencies to avoid security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+		<jackson.version>2.9.9.1</jackson.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.15</version><!--$NO-MVN-MAN-VER$ -->
+			<version>8.0.16</version><!--$NO-MVN-MAN-VER$ -->
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<jackson.version>2.9.9.1</jackson.version>
+		<jackson.version>2.9.9.20190727</jackson.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
These commits update two dependencies to their latest versions to avoid security vulnerabilities. Until FasterXML/jackson-bom#22 is merged the Jackson version-bump won't actually work, but once it *is* merged this PR can be switched from "draft" to "ready," and then once it's been tested it can be merged.