### PR TITLE
Bump to latest Spring and Jackson-BOM versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.6.RELEASE</version>
+		<version>2.1.7.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.st.utopia</groupId>
@@ -19,7 +19,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<jackson.version>2.9.9.20190727</jackson.version>
+		<jackson.version>2.9.9.20190807</jackson.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
I haven't even build-tested this, but since the same change
didn't break the booking service's build, I expect this should
be fine.